### PR TITLE
Add signature generation examples for all SDKs

### DIFF
--- a/docs/generating-signature.md
+++ b/docs/generating-signature.md
@@ -1,0 +1,53 @@
+# Generating a Signature
+To create a token you must first authenticate your requests using a signature. You can use one of the three official Rebilly SDKs to generate and inject it into the page containing the library.
+
+## PHP SDK
+The Rebilly SDK for PHP makes it easy for developers to access Rebilly REST APIs in their PHP code. You can get started in minutes by installing the SDK through Composer or by downloading a single zip file from the latest release.
+
+> See the [Rebilly PHP SDK][goto-php-sdk]{: target="_blank"}
+
+**Generate the signature**
+
+```php
+<?php
+$signature = \Rebilly\Util\RebillySignature::generateSignature(
+    $apiUser,
+    $apiKey
+);
+```
+
+
+## .NET SDK
+The Rebilly NET SDK makes it easy for developers to access Rebilly REST APIs from their .NET code.
+
+> See the [Rebilly .NET SDK][goto-dot-net-sdk]{: target="_blank"}
+
+**Generate the signature**
+
+```c#
+using Rebilly;
+
+var NewSignature = new Signature();
+var SignatureText = NewSignature.Generate("apiUser", "apiKey");
+```
+
+
+## JS SDK (Node)
+The Rebilly JS SDK library allows you to consume the Rebilly API using either Node or the browser.
+
+!!! warning "Server-side Only"
+    You should use the signature generation method only on the server-side as it will otherwise expose your secret `apiKey` to the browser.
+
+> See the [Rebilly JS SDK][goto-js-sdk]{: target="_blank"}
+
+**Generate the signature**
+
+```js
+const api = RebillyAPI({apiKey});
+const signature = api.generateSignature({apiUser, apiKey}); 
+```
+
+
+[goto-php-sdk]: https://github.com/Rebilly/rebilly-php
+[goto-dot-net-sdk]: https://github.com/Rebilly/Rebilly-NET-SDK
+[goto-js-sdk]: https://github.com/Rebilly/rebilly-js-sdk

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -137,4 +137,4 @@ When combined together the most basic version of the page would look like the fo
 <script src="https://gist.github.com/Teknologica/6d814f041428e5255df07cd2c60d1334.js"></script>
 
 [goto-auth]: #Authentication
-[goto-generate]: #test
+[goto-generate]: generating-signature.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ markdown_extensions:
 pages:
   - Introduction: index.md
   - Getting Started: getting-started.md
+  - Generating a Signature: generating-signature.md
   - Validation Tools: validation-tools.md
   - Common Errors: common-errors.md
   - License: license.md


### PR DESCRIPTION
To create a token we need to generate a signature. This PR adds documentation for that purpose.