### PR TITLE
Use correct library target and export for the window in webpack

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
 import Rebilly from './rebilly';
 import modules from './modules';
 
-window.Rebilly = new Rebilly({modules});
+export default new Rebilly({modules});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,9 +9,9 @@ module.exports = (env = {}) => {
             output: {
                 path: path.resolve(__dirname, './dist'),
                 filename: 'rebilly.js',
-                library: 'rebilly-js',
-                libraryTarget: 'umd',
-                umdNamedDefine: true
+                library: 'Rebilly',
+                libraryTarget: 'window',
+                libraryExport: 'default'
             },
             module: {
                 rules: [


### PR DESCRIPTION
This will remove the need for manually exposing the library and use webpack instead.