### PR TITLE
Add API consumer header

### DIFF
--- a/src/handler.js
+++ b/src/handler.js
@@ -1,4 +1,5 @@
 import xhr from 'xhr';
+import {version} from '../package.json';
 
 /**
  * Handler for the creation of a payment token using the Rebilly API. Partially exposed by the main Rebilly factory.
@@ -149,7 +150,8 @@ export default class Handler {
             uri: this.endpoint,
             //json: true,
             headers: {
-                'reb-auth': this.authorization
+                'reb-auth': this.authorization,
+                'reb-api-consumer': `RebillySDK/JS-Token ${version}`
             }
         };
     }

--- a/test/handler.spec.js
+++ b/test/handler.spec.js
@@ -1,5 +1,6 @@
 import chai from 'chai';
 import Handler from '../src/handler';
+import {version} from '../package.json';
 
 const expect = chai.expect;
 
@@ -30,6 +31,7 @@ describe('when creating a handler', () => {
 
         expect(config.uri).to.be.equal(handler.endpoint);
         expect(config.headers['reb-auth']).to.be.equal(handler.authorization);
+        expect(config.headers['reb-api-consumer']).to.be.equal(`RebillySDK/JS-Token ${version}`);
         expect(config.body).to.be.equal(JSON.stringify(data));
     });
 


### PR DESCRIPTION
Add API consumer header to allow Rebilly to identify requests from the library more easily.