### PR TITLE
Allow leadSource overwrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ After including the library into your page, you must authenticate your API reque
 Once included in your checkout page, authenticate your token requests using a publishable API key [generated in Rebilly](https://app.rebilly.com/api-keys/add).
 
 ```js
-// arguments: payload, callback, extraData
-Rebilly.createToken(Node|Object, Function[, Object])
+Rebilly.setPublishableKey('pk_live_...');
 ```
  
 ### Creating a token

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add Rebilly.js to your page using the following CDN provider, preferably at the 
 #### Rebilly CDN
 
 ```html
-<script src="https://cdn.rebilly.com/rebilly-js-token@1.3.0/rebilly.js"></script>
+<script src="https://cdn.rebilly.com/rebilly-js-token@1.4.0/rebilly.js"></script>
 ```
 
 The library is then available in the global scope as `Rebilly`.
@@ -34,16 +34,20 @@ After including the library into your page, you must authenticate your API reque
 Once included in your checkout page, authenticate your token requests using a publishable API key [generated in Rebilly](https://app.rebilly.com/api-keys/add).
 
 ```js
-Rebilly.setPublishableKey('pk_live_...');
+// arguments: payload, callback, extraData
+Rebilly.createToken(Node|Object, Function[, Object])
 ```
  
 ### Creating a token
 To create a token you must provide two parameters: the form or object literal with the payment instrument data (payment card or bank account) and a callback function that will receive the resulting token from the Rebilly API.
 
+Optionally you can also include an object literal defining `extraData` to combine to the main payload. This is useful when using a form to include information about the lead source.
+
 > Tip: when creating a token, prevent the default submission of the form until a value is returned by the API and injected into your page.
 
 ```js
-Rebilly.createToken(Node|Object, Function)
+// payload, callback, extraData
+Rebilly.createToken(Node|Object, Function[, Object])
 ```
 
 #### Building the payment instrument data

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,7 +14,7 @@ Add Rebilly.js to your page using the following CDN provider, preferably at the 
 *Rebilly CDN*
 
 ```html
-<script src="https://cdn.rebilly.com/rebilly-js-token@1.3.0/rebilly.js"></script>
+<script src="https://cdn.rebilly.com/rebilly-js-token@1.4.0/rebilly.js"></script>
 ```
 
 The library is then available in the global scope as `:::js Rebilly`.
@@ -31,11 +31,14 @@ Rebilly.setPublishableKey('pk_live_...');
 ## Creating a token
 To create a token you must provide two parameters: the form or object literal with the payment instrument data (payment card or bank account) and a callback function that will receive the resulting token from the Rebilly API.
 
+Optionally you can also include an object literal defining `extraData` to combine to the main payload. This is useful when using a form to include information about the lead source.
+
 !!! tip "Form Submission"
     When creating a token, prevent the default submission of the form until a value is returned by the API and injected into your page.
 
 ```js
-Rebilly.createToken(Node|Object, Function)
+// arguments: payload, callback, extraData
+Rebilly.createToken(Node|Object, Function[, Object])
 ```
 
 ### Building the payment instrument data

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ Add Rebilly.js to your page using one of the following CDN providers, preferably
 *Rebilly CDN*
 
 ```html
-<script src="https://cdn.rebilly.com/rebilly-js-token@1.3.0/rebilly.js"></script>
+<script src="https://cdn.rebilly.com/rebilly-js-token@1.4.0/rebilly.js"></script>
 ```
 
 ## Semver

--- a/docs/methods.md
+++ b/docs/methods.md
@@ -16,10 +16,11 @@ Rebilly.setPublishableKey('pk_live_...');
 ```
 
 ## createToken
-<div class="method"><code><strong>createToken</strong>(<span class="prop">payload</span>, <span class="prop">callback</span>)</code></div>
+<div class="method"><code><strong>createToken</strong>(<span class="prop">payload</span>, <span class="prop">callback</span>, <span class="prop">extraData</span><span class="optional" title="optional">opt</span>)</code></div>
 
 Trigger an API call to Rebilly that will generate a token for the payment instrument information provided in the `payload`. Once the request completes, the `callback` function is called with the response. 
 
+Optionally you can also include an object literal defining `extraData` to combine to the main payload. This is useful when using a form to include information about the lead source.
 
 **Example**
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "fingerprintjs2": "^1.5.1",
     "mocha": "^4.0.0",
     "rimraf": "^2.6.2",
+    "sinon": "^6.1.5",
     "webpack": "^3.6.0",
     "xhr": "^2.4.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,22 @@
 # yarn lockfile v1
 
 
+"@sinonjs/commons@^1.0.1":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.0.2.tgz#3e0ac737781627b8844257fadc3d803997d0526e"
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/formatio@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-2.0.0.tgz#84db7e9eb5531df18a8c5e0bfb6e449e55e654b2"
+  dependencies:
+    samsam "1.3.0"
+
+"@sinonjs/samsam@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-2.0.0.tgz#9163742ac35c12d3602dece74317643b35db6a80"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -1105,6 +1121,10 @@ diff@3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.1.tgz#aa8567a6eed03c531fc89d3f711cd0e5259dec75"
 
+diff@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+
 diffie-hellman@^5.0.0:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.2.tgz#b5835739270cfe26acf632099fded2a07f209e5e"
@@ -1498,6 +1518,10 @@ has-flag@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
 
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
@@ -1711,6 +1735,10 @@ is-windows@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.1.tgz#310db70f742d259a16a369202b51af84233310d9"
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -1784,6 +1812,10 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+just-extend@^1.1.27:
+  version "1.1.27"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-1.1.27.tgz#ec6e79410ff914e472652abfa0e603c03d60e905"
+
 kind-of@^3.0.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -1834,9 +1866,17 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
 lodash@^4.14.0, lodash@^4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+lolex@^2.3.2, lolex@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.7.1.tgz#e40a8c4d1f14b536aa03e42a537c7adbaf0c20be"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -1976,6 +2016,16 @@ ms@2.0.0:
 nan@^2.3.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
+
+nise@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.4.2.tgz#a9a3800e3994994af9e452333d549d60f72b8e8c"
+  dependencies:
+    "@sinonjs/formatio" "^2.0.0"
+    just-extend "^1.1.27"
+    lolex "^2.3.2"
+    path-to-regexp "^1.7.0"
+    text-encoding "^0.6.4"
 
 node-libs-browser@^2.0.0:
   version "2.0.0"
@@ -2178,6 +2228,12 @@ path-key@^2.0.0:
 path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^2.0.0:
   version "2.0.0"
@@ -2455,6 +2511,10 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, 
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
+samsam@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.3.0.tgz#8d1d9350e25622da30de3e44ba692b5221ab7c50"
+
 "semver@2 || 3 || 4 || 5", semver@^5.3.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
@@ -2495,6 +2555,20 @@ shebang-regex@^1.0.0:
 signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+sinon@^6.1.5:
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-6.1.5.tgz#41451502d43cd5ffb9d051fbf507952400e81d09"
+  dependencies:
+    "@sinonjs/commons" "^1.0.1"
+    "@sinonjs/formatio" "^2.0.0"
+    "@sinonjs/samsam" "^2.0.0"
+    diff "^3.5.0"
+    lodash.get "^4.4.2"
+    lolex "^2.7.1"
+    nise "^1.4.2"
+    supports-color "^5.4.0"
+    type-detect "^4.0.8"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -2628,6 +2702,12 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
+supports-color@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
+  dependencies:
+    has-flag "^3.0.0"
+
 tapable@^0.2.7:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.2.8.tgz#99372a5c999bf2df160afc0d74bed4f47948cd22"
@@ -2652,6 +2732,10 @@ tar@^2.2.1:
     block-stream "*"
     fstream "^1.0.2"
     inherits "2"
+
+text-encoding@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
 
 timers-browserify@^2.0.2:
   version "2.0.4"
@@ -2694,6 +2778,10 @@ tunnel-agent@^0.6.0:
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
+
+type-detect@4.0.8, type-detect@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
 
 type-detect@^4.0.0:
   version "4.0.3"


### PR DESCRIPTION
Allow leadSource overwrite. If present in the payload of the form, or defined as `extraData`, include it instead of the UTM value found in the querystring.